### PR TITLE
UseStaticWebAssets() on webBuilder in Program.cs to prevent web asset…

### DIFF
--- a/src/.template.base/server/Program.cs
+++ b/src/.template.base/server/Program.cs
@@ -20,6 +20,7 @@ namespace MudBlazor.Template
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
+                    webBuilder.UseStaticWebAssets();
                     webBuilder.UseStartup<Startup>();
                 });
     }


### PR DESCRIPTION
…s not being loaded in environments other than Development