### PR TITLE
Prevent 404 on assets when hosting from ASPNET server with different environment

### DIFF
--- a/src/.template.base/server/Program.cs
+++ b/src/.template.base/server/Program.cs
@@ -1,9 +1,12 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Hosting.StaticWebAssets;
 using MudBlazor.Template.Data;
 using MudBlazor.Services;
 
 var builder = WebApplication.CreateBuilder(args);
+
+StaticWebAssetsLoader.UseStaticWebAssets(builder.Environment, builder.Configuration);
 
 // Add services to the container.
 builder.Services.AddRazorPages();

--- a/src/.template.base/wasm-hosted/Server/Program.cs
+++ b/src/.template.base/wasm-hosted/Server/Program.cs
@@ -1,6 +1,9 @@
-﻿using Microsoft.AspNetCore.ResponseCompression;
+﻿using Microsoft.AspNetCore.Hosting.StaticWebAssets;
+using Microsoft.AspNetCore.ResponseCompression;
 
 var builder = WebApplication.CreateBuilder(args);
+
+StaticWebAssetsLoader.UseStaticWebAssets(builder.Environment, builder.Configuration);
 
 // Add services to the container.
 


### PR DESCRIPTION
Added StaticWebAssests loader to prevent 404 when using a different ASPNETCORE_ENVIRONMENT
Fixes #44
