### PR TITLE
Minor dotnet CLI update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## Getting Started
 ### Installation
 ```
-dotnet new --install MudBlazor.Templates
+dotnet new install MudBlazor.Templates
 ```
 ### Usage
 ```


### PR DESCRIPTION
Hi there 👋 

While installing the templates, I got a deprecation warning, so I thought I'd fix it.

`dotnet new --install` is deprecated, I updated it to `dotnet new install`

![image](https://user-images.githubusercontent.com/21295394/216837045-ccbf449b-9e15-4f14-b68d-8b428b12f351.png)
