### PR TITLE
Add `MudStaticNavDrawerToggle` on `IndividualLocalAuth` projects

### DIFF
--- a/InstallAndBuildAllTemplates.ps1
+++ b/InstallAndBuildAllTemplates.ps1
@@ -29,6 +29,12 @@ dotnet build $(Join-Path $tests 'InteractivityWebAssembly_AllInteractive') /warn
 dotnet new mudblazor --interactivity Auto --output $(Join-Path $tests 'InteractivityAuto_Auth') --auth Individual
 dotnet build $(Join-Path $tests 'InteractivityAuto_Auth') /warnaserror
 
+dotnet new mudblazor --interactivity Server --output $(Join-Path $tests 'InteractivityServer_Auth') --auth Individual
+dotnet build $(Join-Path $tests 'InteractivityServer_Auth') /warnaserror
+
+dotnet new mudblazor --interactivity WebAssembly --output $(Join-Path $tests 'InteractivityWebAssembly_Auth') --auth Individual
+dotnet build $(Join-Path $tests 'InteractivityWebAssembly_Auth') /warnaserror
+
 dotnet new mudblazor --interactivity Auto --output $(Join-Path $tests 'InteractivityAuto_AllInteractive_Auth') --all-interactive --auth Individual
 dotnet build $(Join-Path $tests 'InteractivityAuto_AllInteractive_Auth') /warnaserror
 

--- a/InstallAndBuildAllTemplates.ps1
+++ b/InstallAndBuildAllTemplates.ps1
@@ -14,17 +14,17 @@ dotnet build $(Join-Path $tests '/InteractivityAuto') /warnaserror
 dotnet new mudblazor --interactivity Server --output $(Join-Path $tests 'InteractivityServer')
 dotnet build $(Join-Path $tests 'InteractivityServer') /warnaserror
 
-dotnet new mudblazor --interactivity WebAssembly --output $(Join-Path $tests 'InteractivityWebAssembly')
-dotnet build $(Join-Path $tests 'InteractivityWebAssembly') /warnaserror
+dotnet new mudblazor --interactivity WebAssembly --output $(Join-Path $tests 'InteractivityWasm')
+dotnet build $(Join-Path $tests 'InteractivityWasm') /warnaserror
 
-dotnet new mudblazor --interactivity Auto --output $(Join-Path $tests 'InteractivityAuto_AllInteractive') --all-interactive
-dotnet build $(Join-Path $tests 'InteractivityAuto_AllInteractive') /warnaserror
+dotnet new mudblazor --interactivity Auto --output $(Join-Path $tests 'InteractivityAuto_Global') --all-interactive
+dotnet build $(Join-Path $tests 'InteractivityAuto_Global') /warnaserror
 
-dotnet new mudblazor --interactivity Server --output $(Join-Path $tests 'InteractivityServer_AllInteractive') --all-interactive
-dotnet build $(Join-Path $tests 'InteractivityServer_AllInteractive') /warnaserror
+dotnet new mudblazor --interactivity Server --output $(Join-Path $tests 'InteractivityServer_Global') --all-interactive
+dotnet build $(Join-Path $tests 'InteractivityServer_Global') /warnaserror
 
-dotnet new mudblazor --interactivity WebAssembly --output $(Join-Path $tests 'InteractivityWebAssembly_AllInteractive') --all-interactive
-dotnet build $(Join-Path $tests 'InteractivityWebAssembly_AllInteractive') /warnaserror
+dotnet new mudblazor --interactivity WebAssembly --output $(Join-Path $tests 'InteractivityWasm_Global') --all-interactive
+dotnet build $(Join-Path $tests 'InteractivityWasm_Global') /warnaserror
 
 dotnet new mudblazor --interactivity Auto --output $(Join-Path $tests 'InteractivityAuto_Auth') --auth Individual
 dotnet build $(Join-Path $tests 'InteractivityAuto_Auth') /warnaserror
@@ -32,11 +32,11 @@ dotnet build $(Join-Path $tests 'InteractivityAuto_Auth') /warnaserror
 dotnet new mudblazor --interactivity Server --output $(Join-Path $tests 'InteractivityServer_Auth') --auth Individual
 dotnet build $(Join-Path $tests 'InteractivityServer_Auth') /warnaserror
 
-dotnet new mudblazor --interactivity WebAssembly --output $(Join-Path $tests 'InteractivityWebAssembly_Auth') --auth Individual
-dotnet build $(Join-Path $tests 'InteractivityWebAssembly_Auth') /warnaserror
+dotnet new mudblazor --interactivity WebAssembly --output $(Join-Path $tests 'InteractivityWasm_Auth') --auth Individual
+dotnet build $(Join-Path $tests 'InteractivityWasm_Auth') /warnaserror
 
-dotnet new mudblazor --interactivity Auto --output $(Join-Path $tests 'InteractivityAuto_AllInteractive_Auth') --all-interactive --auth Individual
-dotnet build $(Join-Path $tests 'InteractivityAuto_AllInteractive_Auth') /warnaserror
+dotnet new mudblazor --interactivity Auto --output $(Join-Path $tests 'InteractivityAuto_Global_Auth') --all-interactive --auth Individual
+dotnet build $(Join-Path $tests 'InteractivityAuto_Global_Auth') /warnaserror
 
 dotnet new mudblazor --interactivity Auto --output $(Join-Path $tests 'InteractivityAuto_UseMain') --use-program-main
 dotnet build $(Join-Path $tests 'InteractivityAuto_UseMain') /warnaserror

--- a/src/MudBlazor.Templates.csproj
+++ b/src/MudBlazor.Templates.csproj
@@ -4,7 +4,7 @@
     <!-- The package metadata. Fill in the properties marked as TODO below -->
     <!-- Follow the instructions on https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices -->
     <PackageId>MudBlazor.Templates</PackageId>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <Title>MudBlazor Templates</Title>
     <Company>MudBlazor</Company>
     <Authors>MudBlazor Team and Contributors</Authors>

--- a/src/mudblazor/MudBlazor.Template.Client/MudBlazor.Template.Client.csproj
+++ b/src/mudblazor/MudBlazor.Template.Client/MudBlazor.Template.Client.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.*" Condition="'$(IndividualLocalAuth)' == 'True'" />
-	<PackageReference Include="Extensions.MudBlazor.StaticInput" Version="3.*" Condition="'$(IndividualLocalAuth)' == 'True'" />
+    <PackageReference Include="Extensions.MudBlazor.StaticInput" Version="3.*" Condition="'$(IndividualLocalAuth)' == 'True'" />
     <PackageReference Include="MudBlazor" Version="8.*" />
   </ItemGroup>
 

--- a/src/mudblazor/MudBlazor.Template.Client/MudBlazor.Template.Client.csproj
+++ b/src/mudblazor/MudBlazor.Template.Client/MudBlazor.Template.Client.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.*" Condition="'$(IndividualLocalAuth)' == 'True'" />
+	<PackageReference Include="Extensions.MudBlazor.StaticInput" Version="3.*" Condition="'$(IndividualLocalAuth)' == 'True'" />
     <PackageReference Include="MudBlazor" Version="8.*" />
   </ItemGroup>
 

--- a/src/mudblazor/MudBlazor.Template.Client/_Imports.razor
+++ b/src/mudblazor/MudBlazor.Template.Client/_Imports.razor
@@ -2,6 +2,7 @@
 @using System.Net.Http.Json
 @*#if (IndividualLocalAuth)
 @using Microsoft.AspNetCore.Components.Authorization
+@using MudBlazor.StaticInput
 ##endif*@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing

--- a/src/mudblazor/MudBlazor.Template/Components/Layout/MainLayout.razor
+++ b/src/mudblazor/MudBlazor.Template/Components/Layout/MainLayout.razor
@@ -13,7 +13,9 @@
 ##endif*@
 <MudLayout>
     <MudAppBar Elevation="1">
-        @*#if (InteractiveAtRoot)
+        @*#if (IndividualLocalAuth)
+        <MudStaticNavDrawerToggle DrawerId="nav-drawer" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />
+        ##elseif (InteractiveAtRoot)
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
         ##endif*@
         <MudText Typo="Typo.h5" Class="ml-3">Application</MudText>
@@ -25,7 +27,7 @@
         <MudIconButton Icon="@Icons.Material.Filled.MoreVert" Color="Color.Inherit" Edge="Edge.End" />
         ##endif*@
     </MudAppBar>
-    <MudDrawer @bind-Open="_drawerOpen" ClipMode="DrawerClipMode.Always" Elevation="2">
+    <MudDrawer id="nav-drawer" @bind-Open="_drawerOpen" ClipMode="DrawerClipMode.Always" Elevation="2">
         <NavMenu />
     </MudDrawer>
     <MudMainContent Class="mt-16 pa-4">
@@ -60,14 +62,11 @@
         };
     }
 
-    ##endif*@
-
     private void DrawerToggle()
     {
         _drawerOpen = !_drawerOpen;
     }
 
-    @*#if (!IndividualLocalAuth)
     private void DarkModeToggle()
     {
         _isDarkMode = !_isDarkMode;


### PR DESCRIPTION
Introduces the use of the `MudStaticNavDrawerToggle` component in projects generated using `IndividualLocalAuth`. 
This allows the `MudDrawer` to be opened and closed on static (account) pages. 
