### PR TITLE
Fixing MudAlert for RTL layout

### DIFF
--- a/src/mudblazor/MudBlazor.Template/Components/Pages/Home.razor
+++ b/src/mudblazor/MudBlazor.Template/Components/Pages/Home.razor
@@ -5,7 +5,7 @@
 <MudText Typo="Typo.h3" GutterBottom="true">Hello, world!</MudText>
 <MudText Class="mb-8">Welcome to your new app, powered by MudBlazor and the .NET 9 Template!</MudText>
 
-<MudAlert Severity="Severity.Normal">
+<MudAlert Severity="Severity.Normal" ContentAlignment="HorizontalAlignment.Start">
     You can find documentation and examples on our website here:
     <MudLink Href="https://mudblazor.com" Target="_blank" Typo="Typo.body2" Color="Color.Primary">
         <b>www.mudblazor.com</b>


### PR DESCRIPTION
When the layout is set to **LTR**, the MudAlert component displays correctly, as shown below:
![1](https://github.com/user-attachments/assets/b86af94a-e9b7-4b3d-b8df-6e59a07711b8)

However, when the layout is switched to **RTL**, the **MudAlert** component does not render properly:
![2](https://github.com/user-attachments/assets/6e9b43d6-d6dd-4177-9158-c91dd1ce3d72)

To address this issue, I've added the following property to the component:
`ContentAlignment="HorizontalAlignment.Start"`

This adjustment ensures that the **MudAlert** component now displays correctly in both **LTR** and **RTL** layouts:
![3](https://github.com/user-attachments/assets/cfd6ff8a-08b8-4ed4-92cb-d2fc77d91f1c)

With this fix, developers evaluating MudBlazor using the template will no longer encounter this minor inconsistency, resulting in a smoother and more seamless experience.