### PR TITLE
Fixes nav drawer closing when navigating between interactive and static pages

### DIFF
--- a/src/mudblazor/MudBlazor.Template/Components/Layout/MainLayout.razor
+++ b/src/mudblazor/MudBlazor.Template/Components/Layout/MainLayout.razor
@@ -14,7 +14,7 @@
 <MudLayout>
     <MudAppBar Elevation="1">
         @*#if (IndividualLocalAuth)
-        <MudStaticNavDrawerToggle DrawerId="nav-drawer" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />
+        <MudStaticNavDrawerToggle @bind-Open="_drawerOpen" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />
         ##elseif (InteractiveAtRoot)
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
         ##endif*@


### PR DESCRIPTION
It looks like changes have been made to how this works with MudBlazor.StaticInput v4.0.0 which caused the nav drawer to sometimes close when navigating between interactive and static pages.
I updated the template to match how the MudBlazor.StaticInput demo uses the MudStaticNavDrawerToggle component which seems to fix the issue.
