### PR TITLE
Fixes nav drawer generating two different cookies for open state

### DIFF
--- a/src/mudblazor/MudBlazor.Template/Components/Layout/MainLayout.razor
+++ b/src/mudblazor/MudBlazor.Template/Components/Layout/MainLayout.razor
@@ -14,7 +14,7 @@
 <MudLayout>
     <MudAppBar Elevation="1">
         @*#if (IndividualLocalAuth)
-        <MudStaticNavDrawerToggle @bind-Open="_drawerOpen" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />
+        <MudStaticNavDrawerToggle DrawerId="nav-drawer" @bind-Open="_drawerOpen" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />
         ##elseif (InteractiveAtRoot)
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
         ##endif*@


### PR DESCRIPTION
Previous fix I removed DrawerId from MudStaticNavDrawerToggle which caused it to generate a default cookie along side the cookie generated from the MudDrawer id. Removing the id from MudDrawer would have fixed the issue as both would then use the default cookie name, but I decided to add DrawerId back and be more explicit which also solves the problem.