### PR TITLE
Rework ReconnectModal

### DIFF
--- a/src/MudBlazor.Templates.csproj
+++ b/src/MudBlazor.Templates.csproj
@@ -4,7 +4,7 @@
     <!-- The package metadata. Fill in the properties marked as TODO below -->
     <!-- Follow the instructions on https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices -->
     <PackageId>MudBlazor.Templates</PackageId>
-    <Version>4.1.2</Version>
+    <Version>4.2.0</Version>
     <Title>MudBlazor Templates</Title>
     <Company>MudBlazor</Company>
     <Authors>MudBlazor Team and Contributors</Authors>

--- a/src/mudblazor/MudBlazor.Template/Components/Layout/ReconnectModal.razor
+++ b/src/mudblazor/MudBlazor.Template/Components/Layout/ReconnectModal.razor
@@ -5,31 +5,48 @@
 ##endif*@
 
 <dialog id="components-reconnect-modal" data-nosnippet>
-    <div class="components-reconnect-container">
-        <div class="components-rejoining-animation" aria-hidden="true">
-            <div></div>
-            <div></div>
-        </div>
-        <p class="components-reconnect-first-attempt-visible">
-            Rejoining the server...
-        </p>
-        <p class="components-reconnect-repeated-attempt-visible">
-            Rejoin failed... trying again in <span id="components-seconds-to-next-attempt"></span> seconds.
-        </p>
-        <p class="components-reconnect-failed-visible">
-            Failed to rejoin.<br />Please retry or reload the page.
-        </p>
-        <button id="components-reconnect-button" class="components-reconnect-failed-visible">
-            Retry
-        </button>
-        <p class="components-pause-visible">
-            The session has been paused by the server.
-        </p>
-        <p class="components-resume-failed-visible">
-            Failed to resume the session.<br />Please retry or reload the page.
-        </p>
-        <button id="components-resume-button" class="components-pause-visible components-resume-failed-visible">
-            Resume
-        </button>
+    <div class="components-reconnect-backdrop">
+        <section class="components-reconnect-surface" aria-live="assertive" aria-atomic="true">
+            <header class="components-reconnect-header">
+                <span class="components-reconnect-status-dot" aria-hidden="true"></span>
+                <h2>Connection Interrupted</h2>
+            </header>
+
+            <p class="components-reconnect-supporting">
+                Your current session is still open. We'll keep trying to restore it.
+            </p>
+
+            <div class="components-rejoin-loader components-reconnect-first-attempt-visible components-reconnect-repeated-attempt-visible" aria-hidden="true">
+                <div></div>
+                <div></div>
+                <div></div>
+            </div>
+
+            <p class="components-reconnect-first-attempt-visible components-reconnect-message">
+                Rejoining the server...
+            </p>
+            <p class="components-reconnect-repeated-attempt-visible components-reconnect-message">
+                Rejoin failed. Trying again in <span id="components-seconds-to-next-attempt"></span>s.
+            </p>
+            <p class="components-reconnect-failed-visible components-reconnect-message components-reconnect-danger">
+                Failed to rejoin. Retry now or reload the page.
+            </p>
+
+            <p class="components-pause-visible components-reconnect-message">
+                The session has been paused by the server.
+            </p>
+            <p class="components-resume-failed-visible components-reconnect-message components-reconnect-danger">
+                Failed to resume the session. Retry now or reload the page.
+            </p>
+
+            <div class="components-reconnect-actions">
+                <button id="components-reconnect-button" class="components-reconnect-failed-visible" type="button">
+                    Retry
+                </button>
+                <button id="components-resume-button" class="components-pause-visible components-resume-failed-visible" type="button">
+                    Resume
+                </button>
+            </div>
+        </section>
     </div>
 </dialog>

--- a/src/mudblazor/MudBlazor.Template/Components/Layout/ReconnectModal.razor.css
+++ b/src/mudblazor/MudBlazor.Template/Components/Layout/ReconnectModal.razor.css
@@ -5,12 +5,9 @@
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: 1000;
+    z-index: 1400;
     overflow: hidden;
-    background-color: #fff;
-    opacity: 0.9;
-    text-align: center;
-    font-weight: bold;
+    background-color: transparent;
     border: none;
     width: 100%;
     max-width: 100%;
@@ -19,24 +16,90 @@
     padding: 0;
 }
 
+    #components-reconnect-modal::backdrop {
+        background: rgba(10, 16, 28, 0.5);
+    }
+
     #components-reconnect-modal.components-reconnect-show,
-    #components-reconnect-modal[open] {
+    #components-reconnect-modal[open],
+    #components-reconnect-modal.components-reconnect-failed,
+    #components-reconnect-modal.components-reconnect-repeated-attempt,
+    #components-reconnect-modal.components-reconnect-paused,
+    #components-reconnect-modal.components-reconnect-resume-failed,
+    #components-reconnect-modal.components-pause,
+    #components-reconnect-modal.components-resume-failed {
         display: flex;
         align-items: center;
         justify-content: center;
     }
 
-    #components-reconnect-modal.components-reconnect-failed {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-
-.components-reconnect-container {
+.components-reconnect-backdrop {
+    position: fixed;
+    inset: 0;
     display: flex;
-    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: radial-gradient(90% 60% at 80% 0%, color-mix(in srgb, var(--mud-palette-primary, #594AE2) 12%, transparent), transparent 60%), radial-gradient(80% 55% at 0% 100%, color-mix(in srgb, var(--mud-palette-info, #2196f3) 16%, transparent), transparent 62%), rgba(8, 12, 20, 0.5);
+}
+
+.components-reconnect-surface {
+    width: min(480px, 100%);
+    border-radius: var(--mud-default-borderradius, 12px);
+    border: 1px solid color-mix(in srgb, var(--mud-palette-lines-default, #e0e0e0) 70%, transparent);
+    background: var(--mud-palette-surface, #fff);
+    box-shadow: var(--mud-elevation-24, 0 16px 30px rgba(0, 0, 0, 0.28));
+    color: var(--mud-palette-text-primary, #1f2937);
+    padding: 20px 20px 18px;
+}
+
+.components-reconnect-header {
+    display: flex;
     align-items: center;
     gap: 10px;
+    margin-bottom: 8px;
+}
+
+    .components-reconnect-header h2 {
+        margin: 0;
+        font-size: 1.05rem;
+        font-weight: 600;
+        line-height: 1.3;
+    }
+
+.components-reconnect-status-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--mud-palette-warning, #f59e0b);
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--mud-palette-warning, #f59e0b) 25%, transparent);
+}
+
+.components-reconnect-supporting,
+.components-reconnect-message {
+    margin: 0;
+    line-height: 1.45;
+    font-size: 0.95rem;
+}
+
+.components-reconnect-supporting {
+    color: var(--mud-palette-text-secondary, #52607a);
+    margin-bottom: 14px;
+}
+
+.components-reconnect-message {
+    font-weight: 500;
+}
+
+.components-reconnect-danger {
+    color: var(--mud-palette-error, #b00020);
+}
+
+.components-reconnect-actions {
+    margin-top: 14px;
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
 }
 
 .components-reconnect-first-attempt-visible,
@@ -51,6 +114,10 @@ dialog[open].components-reconnect-show .components-reconnect-first-attempt-visib
     display: block;
 }
 
+dialog[open].components-reconnect-show .components-rejoin-loader {
+    display: inline-flex;
+}
+
 dialog[open].components-reconnect-failed .components-reconnect-failed-visible {
     display: block;
 }
@@ -63,41 +130,50 @@ dialog[open].components-reconnect-repeated-attempt .components-reconnect-repeate
     display: block;
 }
 
+dialog[open].components-reconnect-repeated-attempt .components-rejoin-loader {
+    display: inline-flex;
+}
+
+dialog[open].components-reconnect-paused .components-pause-visible,
 dialog[open].components-pause .components-pause-visible {
     display: block;
 }
 
+dialog[open].components-reconnect-paused #components-resume-button,
 dialog[open].components-pause #components-resume-button,
+dialog[open].components-reconnect-resume-failed #components-resume-button,
 dialog[open].components-resume-failed #components-resume-button {
     display: block;
 }
 
+dialog[open].components-reconnect-resume-failed .components-resume-failed-visible,
 dialog[open].components-resume-failed .components-resume-failed-visible {
     display: block;
 }
 
-.components-rejoining-animation {
-    display: flex;
+.components-rejoin-loader {
+    display: none;
+    margin-bottom: 10px;
     gap: 8px;
 }
 
-    .components-rejoining-animation div {
-        width: 12px;
-        height: 12px;
+    .components-rejoin-loader div {
+        width: 9px;
+        height: 9px;
         border-radius: 50%;
         background-color: var(--mud-palette-primary, #594AE2);
-        animation: rejoining-bounce 1.4s infinite ease-in-out both;
+        animation: reconnect-pulse 1.2s infinite ease-in-out both;
     }
 
-        .components-rejoining-animation div:nth-child(1) {
-            animation-delay: -0.32s;
+        .components-rejoin-loader div:nth-child(1) {
+            animation-delay: -0.24s;
         }
 
-        .components-rejoining-animation div:nth-child(2) {
-            animation-delay: -0.16s;
+        .components-rejoin-loader div:nth-child(2) {
+            animation-delay: -0.12s;
         }
 
-@keyframes rejoining-bounce {
+@keyframes reconnect-pulse {
     0%, 80%, 100% {
         transform: scale(0);
     }
@@ -110,11 +186,35 @@ dialog[open].components-resume-failed .components-resume-failed-visible {
 #components-reconnect-button,
 #components-resume-button {
     display: none;
+    min-width: 92px;
     cursor: pointer;
     padding: 8px 16px;
-    border: none;
-    border-radius: 4px;
+    border: 1px solid transparent;
+    border-radius: 999px;
     background-color: var(--mud-palette-primary, #594AE2);
     color: #fff;
-    font-size: 14px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1.2;
+    transition: filter 140ms ease, transform 140ms ease;
+}
+
+    #components-reconnect-button:hover,
+    #components-resume-button:hover {
+        filter: brightness(0.95);
+    }
+
+    #components-reconnect-button:active,
+    #components-resume-button:active {
+        transform: translateY(1px);
+    }
+
+@media (max-width: 600px) {
+    .components-reconnect-backdrop {
+        padding: 14px;
+    }
+
+    .components-reconnect-surface {
+        padding: 16px;
+    }
 }

--- a/src/mudblazor/MudBlazor.Template/Components/Layout/ReconnectModal.razor.js
+++ b/src/mudblazor/MudBlazor.Template/Components/Layout/ReconnectModal.razor.js
@@ -52,7 +52,13 @@ async function resume() {
             location.reload();
         }
     } catch {
-        reconnectModal.classList.replace("components-reconnect-paused", "components-reconnect-resume-failed");
+        if (reconnectModal.classList.contains("components-reconnect-paused")) {
+            reconnectModal.classList.replace("components-reconnect-paused", "components-reconnect-resume-failed");
+        } else if (reconnectModal.classList.contains("components-pause")) {
+            reconnectModal.classList.replace("components-pause", "components-resume-failed");
+        } else {
+            reconnectModal.classList.add("components-reconnect-resume-failed");
+        }
     }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/MudBlazor/Templates/issues/510

Since you can't interact with page when connection is down, I made in in middle and obviously modal with background going black.
Keep in mind it only mimics Mud, everything is in pure html/css/js, since you can't use here Mud Components.
I made it how I see it, who doesn't like it, can always make their own version.


<img width="2550" height="1299" alt="Screenshot 2026-02-28 191743" src="https://github.com/user-attachments/assets/56ff67cf-dd30-4825-abed-80157efc70ea" />
<img width="2549" height="1239" alt="Screenshot 2026-02-28 191759" src="https://github.com/user-attachments/assets/d7cf0084-7a5f-4fea-98b7-08f35913807c" />
