### PR TITLE
Run continuous CI on dev pushes and pull requests

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -16,7 +16,13 @@
 
 name: continuous
 
-on: [push]
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
 
 jobs:
   ubuntu-latest:

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -19,7 +19,8 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
     "continuous",
     GitHubActionsImage.UbuntuLatest,
     FetchDepth = 0,
-    On = [GitHubActionsTrigger.Push],
+    OnPushBranches = ["dev"],
+    OnPullRequestBranches = ["dev"],
     PublishArtifacts = true,
     InvokedTargets = [nameof(Compile), nameof(Pack)])]
 [GitHubActions(


### PR DESCRIPTION
`continuous.yml` triggers on `on: [push]` with no `pull_request` trigger. A `push` event **never fires for a pull request opened from a fork**, so fork PRs reach review without ever being compiled or packed.

`[push]` also matches every branch and every tag. Recent run history shows `continuous` firing on tag `4.3.0` alongside `release.yml` — two concurrent runs building the same commit.

Note that `mudblazor-ci.yml` in this repo already uses the correct shape (`push: branches: [dev]` + `pull_request:`); `continuous.yml` was simply never updated to match.

One of three matching PRs closing the same gap across the org — see MudBlazor/ThemeManager#47 and MudBlazor/MudBlazor.Icons#42.

## Change

```yaml
on:
  push:
    branches:
      - dev
  pull_request:
    branches:
      - dev
```

Because the workflow is generated from the NUKE `[GitHubActions]` attribute, `build/Build.cs` is updated in the same commit so a future regeneration doesn't silently revert the trigger. NUKE rejects mixing shorthand `On` with the expanded `On*` properties, so both triggers are branch-scoped via `OnPushBranches`/`OnPullRequestBranches`.

`release.yml`, `codeql.yml`, `mudblazor-ci.yml`, and `mudblazor-auto-merge.yml` are untouched.

