### PR TITLE
Triage new issues with AutoTriage

### DIFF
--- a/.github/workflows/autotriage.yml
+++ b/.github/workflows/autotriage.yml
@@ -1,0 +1,24 @@
+name: AutoTriage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  triage:
+    if: ${{ github.repository_owner == 'MudBlazor' && github.event.sender.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: danielchalmers/AutoTriage@v4
+        with:
+          issues: ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
Runs the same AutoTriage action as `MudBlazor/MudBlazor`, on newly opened issues only.

**Why:** Templates is what people reach through `dotnet new`, and its issues are user-facing template bugs (#516, #517). Inflow is 3 per 180 days — low enough that nothing is watching, high enough that each one matters.

**Issues only**, no `pull_request_target`. This repo does get real external PRs (4 in 180 days, and it's the only satellite with zero bot PR traffic), so a PR trigger is defensible later — keeping the two decisions separable.

Guards: `repository_owner == 'MudBlazor'` (skips forks) and `sender.type != 'Bot'`. `GEMINI_API_KEY` is already an org secret, so no setup needed.

No `AutoTriage.prompt` — the action falls back to its default policy. Uses `checkout@v7` rather than the `@v4` elsewhere here. Add `dry-run: "true"` to review the plan before it acts.

_Replaces #522, which became unreopenable after a bad force-push._
