### PR TITLE
Fail the build when a template fails to build

### DIFF
--- a/InstallAndBuildAllTemplates.ps1
+++ b/InstallAndBuildAllTemplates.ps1
@@ -1,3 +1,7 @@
+# A failing dotnet exit code is not a PowerShell error, so without these the script runs to the end and reports the exit code of the last build only.
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
 $tests = Join-Path $PSScriptRoot '/tests'
 
 Remove-Item -LiteralPath $tests -Force -Recurse -ErrorAction SilentlyContinue


### PR DESCRIPTION
`InstallAndBuildAllTemplates.ps1` runs 52 `dotnet` commands and never checks an exit code between them. A non-zero exit from a native command is not a PowerShell error, so `$ErrorActionPreference` does not catch it, and the step's exit code is whatever the **last** command returned.

If `InteractivityServer_Auth` breaks at permutation 5 of 26, `WasmStandalone_CallsWebApi` succeeding at the end still turns the job green.

The last 30 `mudblazor-ci` runs are 30/30 success. For a workflow that compiles 26 generated projects with `/warnaserror` against a moving MudBlazor dependency, that record is more suspicious than reassuring.