### PR TITLE
Resolve the SQLitePCLRaw advisory in the Sqlite auth templates

### DIFF
--- a/src/mudblazor/MudBlazor.Template/MudBlazor.Template.csproj
+++ b/src/mudblazor/MudBlazor.Template/MudBlazor.Template.csproj
@@ -30,6 +30,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.*" Condition="'$(IndividualLocalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.*" Condition="'$(IndividualLocalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.*" Condition="'$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />
+    <!-- EF Core still resolves SQLitePCLRaw 2.1.11, which GHSA-2m69-gcr7-jv3q flags as a high severity vulnerability. Remove once EF Core ships a version that resolves 2.1.12 or later on its own. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.*" Condition="'$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.*" Condition="'$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.*" Condition="'$(IndividualLocalAuth)' == 'True'" />
     <PackageReference Include="MudBlazor" Version="9.*" Condition="'$(UseWebAssembly)' != 'True'" />


### PR DESCRIPTION
Every `--auth Individual` template that uses Sqlite currently fails to build:

```
InteractivityAuto_Auth.csproj : error NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11
has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
```

EF Core 10 — including the current 10.0.10 — still resolves SQLitePCLRaw 2.1.11 transitively. The advisory covers `<= 2.1.11`, and `NU1903` is an error under `/warnaserror`, so the build fails. Nobody has had to touch the templates for this to break; it appeared when the advisory was published.

This is what #524 surfaced. `mudblazor-ci` never reported it because the script did not stop on a failing build.

## Fix

Reference `SQLitePCLRaw.bundle_e_sqlite3` explicitly, under the same condition as the Sqlite provider, so it applies only where Sqlite is actually used and not to the `--use-local-db` (SqlServer) variants.

Referencing the bundle rather than `lib.e_sqlite3` directly keeps the whole set on one version. After the change:

```
SQLitePCLRaw.bundle_e_sqlite3     2.*     2.1.12
SQLitePCLRaw.core                         2.1.12
SQLitePCLRaw.lib.e_sqlite3                2.1.12
SQLitePCLRaw.provider.e_sqlite3           2.1.12
```

The floating `2.*` matches the existing style in this file (`10.*`, `9.*`, `4.*`) and picks up future 2.x fixes. The comment marks it for removal once EF Core resolves 2.1.12 or later on its own.

## Verified

All seven Sqlite auth permutations generated and built with `/warnaserror`:

- `InteractivityAuto_Auth`, `InteractivityNone_Auth`, `InteractivityServer_Auth`, `InteractivityWasm_Auth`
- `InteractivityAuto_Global_Auth`, `InteractivityServer_Global_Auth`, `InteractivityWasm_Global_Auth`

All pass. `dotnet list package --vulnerable --include-transitive` reports no vulnerable packages for the generated app or its `.Client` project.

## Merge order

This should go in **before** #524. Once this is merged, #524 makes the workflow able to fail and CI is genuinely green; merging #524 first would leave `dev` red until this lands.